### PR TITLE
Password change fix

### DIFF
--- a/modules/users/server/controllers/users.js
+++ b/modules/users/server/controllers/users.js
@@ -201,14 +201,8 @@ module.exports = function(System) {
     if (req.body.password) {
       user.password = req.body.password;
     }
-    var updates = {
-      name: req.body.name
-    };
-    if (req.body.password) {
-      updates.password = req.body.password;
-    }
 
-    User.update({_id: req.params.userId}, updates, function(err) {
+    return user.save(function(err) {
       if (err) {
         return json.unhappy(err, res);
       }


### PR DESCRIPTION
To implicitly call the virtuals `.set` method of the `/models/user.js`, Mongoose requires a call to the `save()` method, does not anymore work with Model.update. Fixed this now.